### PR TITLE
Uses client's annotation when no server annotation

### DIFF
--- a/src/app/tracechart/tracechart.component.ts
+++ b/src/app/tracechart/tracechart.component.ts
@@ -64,14 +64,14 @@ export class TraceChartComponent implements OnInit {
     }
 
     getCr1(span: Span) {
-        return this.getSystemAnnotation(span, 'ss');
+        return this.getSystemAnnotation(span, 'ss') || this.getSystemAnnotation(span, 'cr');
     }
     getCr2(span: Span) {
         return this.getSystemAnnotation(span, 'cr') - this.getSystemAnnotation(span, 'ss');
     }
 
     getSr(span: Span) {
-        return this.getSystemAnnotation(span, 'sr');
+        return this.getSystemAnnotation(span, 'sr') || this.getSystemAnnotation(span, 'cs');
     }
 
     getSs(span: Span) {


### PR DESCRIPTION
So the left of the span is based on the client start, instead of being 0.