### PR TITLE
npm:d3 -> dt:d3 and added dt:dagre

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -2,11 +2,10 @@
   "globalDependencies": {
     "bootstrap": "registry:dt/bootstrap#3.3.5+20160619023404",
     "core-js": "registry:dt/core-js#0.0.0+20160602141332",
+    "d3": "registry:dt/d3#0.0.0+20160907005744",
+    "dagre": "registry:dt/dagre#0.7.0+20160505164908",
     "dagre-d3": "registry:dt/dagre-d3#0.0.0+20160620231311",
     "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
     "node": "registry:dt/node#6.0.0+20160807145350"
-  },
-  "dependencies": {
-    "d3": "registry:npm/d3#3.0.0+20160723033700"
   }
 }


### PR DESCRIPTION
This aims to fix #19 

dt:dagre-d3 refers to ../d3/d3.d.ts, which exists in the dt repo but not
in the npm repo. Not to mention, the d3 typing definitions found in the
npm repo must be installed as modules, so dagre-d3 would have to
reference ../../modules/... to access it.

Dagre typings were simply just missing, but referenced by dagre-d3
typings.