### PR TITLE
make host and port passable, fetch from env for Docker run.

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -5,6 +5,8 @@ var commonConfig = require('./webpack.common.js');
 var helpers = require('./helpers');
 
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
+const ZIPKIN_HOST = process.env.ZIPKIN_HOST;
+const ZIPKIN_PORT = process.env.ZIPKIN_PORT;
 
 module.exports = webpackMerge(commonConfig, {
     devtool: 'source-map',
@@ -27,7 +29,9 @@ module.exports = webpackMerge(commonConfig, {
         new ExtractTextPlugin('[name].[hash].css'),
         new webpack.DefinePlugin({
             'process.env': {
-                'ENV': JSON.stringify(ENV)
+                'ENV': JSON.stringify(ENV),
+                'ZIPKIN_HOST': JSON.stringify(ZIPKIN_HOST),
+                'ZIPKIN_PORT': JSON.stringify(ZIPKIN_PORT)
             }
         })
     ]

--- a/src/app/tracegraph/tracegraph.component.ts
+++ b/src/app/tracegraph/tracegraph.component.ts
@@ -9,15 +9,19 @@ import { Http } from '@angular/http';
 })
 
 export class TraceGraphComponent implements OnInit {
+    baseUri: string;
+    basePort: string;
 
     constructor( @Inject(ElementRef) private element: ElementRef, @Inject(Http) private http: Http) {
+        this.baseUri = process.env.ZIPKIN_HOST || 'localhost';
+        this.basePort = process.env.ZIPKIN_PORT || '9411';
     }
 
     ngOnInit() {
 
         this
             .http
-            .get(`http://localhost:9411/api/v1/dependencies?endTs=1474206961061&lookback=86400000`, {})
+            .get(`http://${this.baseUri}:${this.basePort}/api/v1/dependencies?endTs=1474206961061&lookback=86400000`, {})
             .subscribe(res => {
                 let zip = <any>(res.json());
 

--- a/src/app/zipkin/zipkin.ts
+++ b/src/app/zipkin/zipkin.ts
@@ -155,17 +155,19 @@ export class Trace {
 export class ZipkinService {
     traces: Trace[];
     baseUri: string;
+    basePort: string;
     services: string[];
 
     constructor( @Inject(Http) private http: Http) {
-        this.baseUri = 'localhost';
+        this.baseUri = process.env.ZIPKIN_HOST || 'localhost';
+        this.basePort = process.env.ZIPKIN_PORT || '9411';
         this.traces = null;
     }
 
     getServices() {
         this
             .http
-            .get(`http://${this.baseUri}:9411/api/v1/services`, {})
+            .get(`http://${this.baseUri}:${this.basePort}/api/v1/services`, {})
             .subscribe(res => {
                 this.services = <string[]>(res.json());
                 this.services.push('[any]');
@@ -179,7 +181,7 @@ export class ZipkinService {
         let endTs = startDate.getTime();
         let lookback = endTs - endDate.getTime();
 
-        var uri = `http://${this.baseUri}:9411/api/v1/traces?endTs=${endTs}&lookback=${lookback}&annotationQuery=&limit=${limit}&minDuration=${minDuration}&spanName=all`;
+        var uri = `http://${this.baseUri}:${this.basePort}/api/v1/traces?endTs=${endTs}&lookback=${lookback}&annotationQuery=&limit=${limit}&minDuration=${minDuration}&spanName=all`;
         if (serviceName != undefined && serviceName != '[any]') {
             uri += `&serviceName=${serviceName}`;
         }


### PR DESCRIPTION
make host and port passable, fetch from env for Docker run. 

in the bash shell, before exec `npm run build`, make the env first:
```
export ZIPKIN_HOST=172.16.10.56 ZIPKIN_PORT=32008
```

in the dockerfile,
```
ENV ZIPKIN_HOST 172.16.10.56
ENV ZIPKIN_PORT 32008
COPY ./zipkin-ui /opt/ongo360-demo/
RUN cd /opt/ongo360-demo/zipkin-ui && \
    npm install typescript -g
    rm -rf ./node_modules && \
    npm install && \
    npm run build
```

Update feature for this issue #25  