### PR TITLE
Defaults ZIPKIN_BASE_URL to same origin in production config

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,7 +1,10 @@
+var webpack = require('webpack');
 var webpackMerge = require('webpack-merge');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var commonConfig = require('./webpack.common.js');
 var helpers = require('./helpers');
+
+const ZIPKIN_BASE_URL = process.env.ZIPKIN_BASE_URL || 'http://localhost:9411';
 
 module.exports = webpackMerge(commonConfig, {
     devtool: 'cheap-module-eval-source-map',
@@ -14,7 +17,12 @@ module.exports = webpackMerge(commonConfig, {
     },
 
     plugins: [
-        new ExtractTextPlugin('[name].css')
+        new ExtractTextPlugin('[name].css'),
+        new webpack.DefinePlugin({
+            'process.env': {
+                'ZIPKIN_BASE_URL': JSON.stringify(ZIPKIN_BASE_URL)
+            }
+        }),
     ],
 
     devServer: {

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -5,7 +5,6 @@ var commonConfig = require('./webpack.common.js');
 var helpers = require('./helpers');
 
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
-const ZIPKIN_BASE_URL = process.env.ZIPKIN_BASE_URL;
 
 module.exports = webpackMerge(commonConfig, {
     devtool: 'source-map',
@@ -24,7 +23,6 @@ module.exports = webpackMerge(commonConfig, {
         new webpack.DefinePlugin({
             'process.env': {
                 'ENV': JSON.stringify(ENV),
-                'ZIPKIN_BASE_URL': JSON.stringify(ZIPKIN_BASE_URL)
             }
         }),
         new webpack.LoaderOptionsPlugin({

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,15 @@ $ wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a
 $ java -jar zipkin.jar
 ```
 
+If you want to test against a different zipkin server, export the `ZIPKIN_BASE_URL` appropriately.
+
+```bash
+$ ZIPKIN_BASE_URL=http://192.168.99.100:9411 npm start
+```
+
 ## Production Build
+The production build is made for same origin deployment. Take a look at our [nginx configuration](https://github.com/openzipkin/docker-zipkin/blob/master/zipkin-ui/nginx.conf) for an example. This is used in the "openzipkin/zipkin-ui" docker image.
+
 ```bash
 $ npm run build
 ```

--- a/src/app/tracegraph/tracegraph.component.ts
+++ b/src/app/tracegraph/tracegraph.component.ts
@@ -12,7 +12,7 @@ export class TraceGraphComponent implements OnInit {
     baseUrl: string;
 
     constructor( @Inject(ElementRef) private element: ElementRef, @Inject(Http) private http: Http) {
-        this.baseUrl = process.env.ZIPKIN_BASE_URL || 'http://localhost:9411';
+        this.baseUrl = process.env.ZIPKIN_BASE_URL || ''; // default to same origin
     }
 
     ngOnInit() {

--- a/src/app/zipkin/zipkin.ts
+++ b/src/app/zipkin/zipkin.ts
@@ -158,7 +158,7 @@ export class ZipkinService {
     services: string[];
 
     constructor( @Inject(Http) private http: Http) {
-        this.baseUrl = process.env.ZIPKIN_BASE_URL || 'http://localhost:9411';
+        this.baseUrl = process.env.ZIPKIN_BASE_URL || ''; // default to same origin
         this.traces = null;
     }
 


### PR DESCRIPTION
Previously, you couldn't change `ZIPKIN_BASE_URL` when developing, and
the production build was hard-targeted to localhost. This flips the
preference, so that the production build is fixed to a more realistic
same-origin policy, while development can be changed easily.

See #37