### PR TITLE
specify ng-bootstrap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "2.4.10",
     "@angular/platform-browser-dynamic": "2.4.10",
     "@angular/router": "3.4.10",
-    "@ng-bootstrap/ng-bootstrap": "^1.0.0-alpha.21",
+    "@ng-bootstrap/ng-bootstrap": "1.0.0-alpha.21",
     "angular2-fontawesome": "^0.8.0",
     "bootstrap": "3.3.7",
     "dagre": "^0.7.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postinstall": "typings install",
     "test": "karma start"
   },
+  "//": "specify the ng-bootstrap version to '1.0.0-alpha.24'(the lastest version supportted by angular2), because the newer version need angular4 support.",
   "dependencies": {
     "@angular/common": "2.4.10",
     "@angular/compiler": "2.4.10",
@@ -23,7 +24,7 @@
     "@angular/platform-browser": "2.4.10",
     "@angular/platform-browser-dynamic": "2.4.10",
     "@angular/router": "3.4.10",
-    "@ng-bootstrap/ng-bootstrap": "1.0.0-alpha.21",
+    "@ng-bootstrap/ng-bootstrap": "1.0.0-alpha.24",
     "angular2-fontawesome": "^0.8.0",
     "bootstrap": "3.3.7",
     "dagre": "^0.7.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "typings install",
     "test": "karma start"
   },
-  "//": "specify the ng-bootstrap version to '1.0.0-alpha.24'(the lastest version supportted by angular2), because the newer version need angular4 support.",
+  "//": "the ng-bootstrap version is pinned to the last version supporting angular2; newer versions require angular4",
   "dependencies": {
     "@angular/common": "2.4.10",
     "@angular/compiler": "2.4.10",


### PR DESCRIPTION
I get the error when run `npm start`
```
ERROR in /zipkin-ui/node_modules/@ng-bootstrap/ng-bootstrap/util/popup.d.ts
(1,60): error TS2305: Module '"/zipkin-ui/node_modules/@angular/core/index"' has no exported member 'Renderer2'.
```
The reason is the version of ng-bootstrap is the latest one. but it depend on Angular4,  I specify the ng-bootstrap version to resolve this issue. 

Please review it. Thanks